### PR TITLE
Personalize portfolio

### DIFF
--- a/src/components/AboutSection.jsx
+++ b/src/components/AboutSection.jsx
@@ -12,20 +12,23 @@ export const AboutSection = () => {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-12 items-center">
           <div className="space-y-6">
             <h3 className="text-2xl font-semibold">
-              Passionate Web Developer & Tech Creator
+              Versatile Engineer & Data Enthusiast
             </h3>
 
             <p className="text-muted-foreground">
-              With over 5 years of experience in web development, I specialize
-              in creating responsive, accessible, and performant web
-              applications using modern technologies.
+              I'm a versatile engineer with a passion for building robust,
+              data-centric applications. With a foundation in full-stack
+              development and specialized expertise in data engineering, I
+              transform complex datasets into actionable insights and intuitive
+              user experiences.
             </p>
 
             <p className="text-muted-foreground">
-              I'm passionate about creating elegant solutions to complex
-              problems, and I'm constantly learning new technologies and
-              techniques to stay at the forefront of the ever-evolving web
-              landscape.
+              From developing automated ETL pipelines with Airflow and dbt to
+              engineering responsive frontends in React and Node.js, I thrive at
+              the intersection of data, software, and cloud infrastructure. My
+              goal is to leverage technology to solve challenging problems and
+              drive data-informed decisions.
             </p>
 
             <div className="flex flex-col sm:flex-row gap-4 pt-4 justify-center">

--- a/src/components/ContactSection.jsx
+++ b/src/components/ContactSection.jsx
@@ -127,7 +127,7 @@ export const ContactSection = () => {
                   name="name"
                   required
                   className="w-full px-4 py-3 rounded-md border border-input bg-background focus:outline-none focus:ring-2 focus:ring-primary"
-                  placeholder="Pedro Machado..."
+                  placeholder="Marcus Myrick..."
                 />
               </div>
 

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -6,7 +6,7 @@ export const Footer = () => {
       {" "}
       <p className="text-sm text-muted-foreground">
         {" "}
-        &copy; {new Date().getFullYear()} Pedrotech.co. All rights reserved.
+        &copy; {new Date().getFullYear()} marcusmyrick.com. All rights reserved.
       </p>
       <a
         href="#hero"

--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -12,18 +12,19 @@ export const HeroSection = () => {
             <span className="opacity-0 animate-fade-in"> Hi, I'm</span>
             <span className="text-primary opacity-0 animate-fade-in-delay-1">
               {" "}
-              Pedro
+              Marcus
             </span>
             <span className="text-gradient ml-2 opacity-0 animate-fade-in-delay-2">
               {" "}
-              Machado
+              Myrick
             </span>
           </h1>
 
           <p className="text-lg md:text-xl text-muted-foreground max-w-2xl mx-auto opacity-0 animate-fade-in-delay-3">
-            I create stellar web experiences with modern technologies.
-            Specializing in front-end development, I build interfaces that are
-            both beautiful and functional.
+            I'm a versatile engineer with a passion for building robust, data-centric
+            applications. From automated ETL pipelines with Airflow and dbt to
+            responsive frontends in React and Node.js, I thrive at the intersection
+            of data, software, and cloud infrastructure.
           </p>
 
           <div className="pt-4 opacity-0 animate-fade-in-delay-4">

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -35,7 +35,7 @@ export const Navbar = () => {
           href="#hero"
         >
           <span className="relative z-10">
-            <span className="text-glow text-foreground"> PedroTech </span>{" "}
+            <span className="text-glow text-foreground"> Marcus Myrick </span>{" "}
             Portfolio
           </span>
         </a>

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -1,0 +1,122 @@
+import React, { useState } from "react";
+import { Tilt } from "react-tilt";
+import { motion } from "framer-motion";
+
+import { styles } from "../style";
+import { github } from "../assets";
+import { SectionWrapper } from "../hoc";
+import { projects } from "../constants";
+import { fadeIn, textVariant } from "../utils/motion";
+
+const ProjectCard = ({
+  index,
+  name,
+  description,
+  tags,
+  image,
+  source_code_link,
+}) => {
+  return (
+    <motion.div variants={fadeIn("up", "spring", index * 0.5, 0.75)}>
+      <Tilt
+        options={{
+          max: 45,
+          scale: 1,
+          speed: 450,
+        }}
+        className='bg-tertiary p-5 rounded-2xl sm:w-[360px] w-full'
+      >
+        <div className='relative w-full h-[230px]'>
+          <img
+            src={image}
+            alt='project_image'
+            className='w-full h-full object-cover rounded-2xl'
+          />
+
+          <div className='absolute inset-0 flex justify-end m-3 card-img_hover'>
+            <div
+              onClick={() => window.open(source_code_link, "_blank")}
+              className='black-gradient w-10 h-10 rounded-full flex justify-center items-center cursor-pointer'
+            >
+              <img
+                src={github}
+                alt='source code'
+                className='w-1/2 h-1/2 object-contain'
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className='mt-5'>
+          <h3 className='text-white font-bold text-[24px]'>{name}</h3>
+          <p className='mt-2 text-secondary text-[14px]'>{description}</p>
+        </div>
+
+        <div className='mt-4 flex flex-wrap gap-2'>
+          {tags.map((tag) => (
+            <p
+              key={`${name}-${tag.name}`}
+              className={`text-[14px] ${tag.color}`}
+            >
+              #{tag.name}
+            </p>
+          ))}
+        </div>
+      </Tilt>
+    </motion.div>
+  );
+};
+
+const Projects = () => {
+  const [activeFilter, setActiveFilter] = useState('All');
+  const filterCategories = ['All', 'Software Engineering', 'Data and Analytics', 'Quantitative Development'];
+
+  const filteredProjects = activeFilter === 'All'
+    ? projects
+    : projects.filter(project => project.category === activeFilter);
+
+  return (
+    <>
+      <motion.div variants={textVariant()}>
+        <p className={`${styles.sectionSubText} `}>My work</p>
+        <h2 className={`${styles.sectionHeadText}`}>Projects.</h2>
+      </motion.div>
+
+      <div className='w-full flex'>
+        <motion.p
+          variants={fadeIn("", "", 0.1, 1)}
+          className='mt-3 text-secondary text-[17px] max-w-3xl leading-[30px]'
+        >
+          Following projects showcases my skills and experience through
+          real-world examples of my work. Each project is briefly described with
+          links to code repositories and live demos in it. It reflects my
+          ability to solve complex problems, work with different technologies,
+          and manage projects effectively.
+        </motion.p>
+      </div>
+
+      <div className='mt-10 flex flex-wrap gap-4'>
+        {filterCategories.map(category => (
+          <button
+            key={category}
+            onClick={() => setActiveFilter(category)}
+            className={`py-2 px-4 rounded-lg text-white font-medium text-[16px] transition-all duration-300 ${
+              activeFilter === category ? 'bg-tertiary' : 'bg-[#1d1836] hover:bg-tertiary/70'
+            }`}
+          >
+            {category}
+          </button>
+        ))}
+      </div>
+
+
+      <div className='mt-20 flex flex-wrap gap-7'>
+        {filteredProjects.map((project, index) => (
+          <ProjectCard key={`project-${index}`} index={index} {...project} />
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default SectionWrapper(Projects, "projects");

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,0 +1,248 @@
+import {
+  mobile,
+  backend,
+  creator,
+  web,
+  javascript,
+  typescript,
+  html,
+  css,
+  reactjs,
+  redux,
+  tailwind,
+  nodejs,
+  mongodb,
+  git,
+  figma,
+  docker,
+  meta,
+  starbucks,
+  tesla,
+  shopify,
+  carrent,
+  jobit,
+  tripguide,
+  threejs,
+} from "../assets";
+
+// NOTE: You can find better icons for your specific tech stack.
+// For now, I'm using the default icons as placeholders.
+// You might want to find icons for Python, SQL, AWS, etc.
+// A great place is: https://react-icons.github.io/react-icons/
+
+export const navLinks = [
+  {
+    id: "about",
+    title: "About",
+  },
+  {
+    id: "work",
+    title: "Work",
+  },
+  {
+    id: "projects",
+    title: "Projects",
+  },
+  {
+    id: "contact",
+    title: "Contact",
+  },
+];
+
+const services = [
+  {
+    title: "Data Engineering & Orchestration",
+    icon: backend, // Placeholder Icon
+  },
+  {
+    title: "Backend Web Development",
+    icon: web, // Placeholder Icon
+  },
+  {
+    title: "Cloud & MLOps",
+    icon: creator, // Placeholder Icon
+  },
+  {
+    title: "Full-Stack Development",
+    icon: mobile, // Placeholder Icon
+  },
+];
+
+const technologies = [
+  {
+    name: "Python",
+    icon: redux, // Placeholder Icon
+  },
+  {
+    name: "SQL",
+    icon: shopify, // Placeholder Icon
+  },
+  {
+    name: "dbt",
+    icon: starbucks, // Placeholder Icon
+  },
+  {
+    name: "Apache Airflow",
+    icon: meta, // Placeholder Icon
+  },
+  {
+    name: "React JS",
+    icon: reactjs,
+  },
+  {
+    name: "Node JS",
+    icon: nodejs,
+  },
+  {
+    name: "Docker",
+    icon: docker,
+  },
+  {
+    name: "AWS",
+    icon: tesla, // Placeholder Icon
+  },
+  {
+    name: "PostgreSQL",
+    icon: mongodb, // Placeholder Icon
+  },
+  {
+    name: "Tailwind CSS",
+    icon: tailwind,
+  },
+];
+
+const experiences = [
+  {
+    title: "Data Visualization - Web Development Consultant",
+    company_name: "Hektoen Institute, LLC (COVID Memorial Monument)",
+    icon: meta, // Placeholder Icon
+    iconBg: "#E6DEDD",
+    date: "Sep 2024 - June 2025",
+    points: [
+      "Led development of the COVID Memorial Monument website, using React, PHP, and JavaScript to build a responsive, interactive interface on WordPress.",
+      "Designed and implemented ETL pipelines on Databricks to process website analytics, delivering actionable insights on user engagement.",
+      "Resolved complex technical issues, including custom template integration and REST API communication within WordPress.com hosting constraints.",
+    ],
+  },
+  {
+    title: "Data & Software Engineer",
+    company_name: "John Deere (JDEP Electrification)",
+    icon: tesla, // Placeholder Icon
+    iconBg: "#E6DEDD",
+    date: "July 2023 - Sep 2024",
+    points: [
+      "Engineered a Battery Data Analysis Tool using Python and Dash, automating processing of ~300 GB of data and enabling 30% faster decision-making.",
+      "Developed an interactive Power BI dashboard for real-time data analysis and reporting.",
+      "Improved system performance by 25% by conducting root-cause analysis on 2 TB of production data using SQL and Databricks Delta.",
+      "Built and deployed a Python-based data cleaning tool that enhanced analysis precision by 30% and reduced processing time by 40%.",
+    ],
+  },
+  {
+    title: "Web Development Consultant",
+    company_name: "Hektoen Institute, LLC (Hektoen International)",
+    icon: shopify, // Placeholder Icon
+    iconBg: "#E6DEDD",
+    date: "Nov 2023 - Oct 2024",
+    points: [
+      "Managed and maintained the Hektoen International website, ensuring performance and security using WordPress, PHP, and CSS.",
+      "Reviewed and corrected over 3,000 journal articles with HTML and CSS to enhance formatting and accessibility.",
+      "Developed custom WordPress themes and plugins to streamline website operations.",
+    ],
+  },
+    {
+    title: "Full-Stack Software Development Apprentice",
+    company_name: "Discovery Partners Institute",
+    icon: starbucks, // Placeholder Icon
+    iconBg: "#E6DEDD",
+    date: "Jan 2023 - April 2023",
+    points: [
+      "Engineered 4 key features for Ruby on Rails web applications, including user authentication, data encryption, and full CRUD functionalities.",
+      "Improved overall platform functionality by 25% and increased user satisfaction scores by 20%.",
+      "Managed database interactions to ensure data integrity and responsiveness.",
+    ],
+  },
+];
+
+
+const projects = [
+  {
+    name: "AgentConnect – Full-Stack HR Dashboard",
+    description:
+      "A cloud-native HR platform simulating State Farm’s SSAA application to manage agents, teams, and assignments, featuring a responsive UI and a robust RESTful API.",
+    category: "Software Engineering",
+    tags: [
+      {
+        name: "react",
+        color: "blue-text-gradient",
+      },
+      {
+        name: "nodejs",
+        color: "green-text-gradient",
+      },
+      {
+        name: "postgresql",
+        color: "pink-text-gradient",
+      },
+       {
+        name: "docker",
+        color: "blue-text-gradient",
+      },
+    ],
+    image: carrent, // Placeholder Image
+    source_code_link: "https://github.com/MarcusJMyrick/agentconnect",
+  },
+  {
+    name: "Marketing ROI Intelligence Platform",
+    description:
+      "An end-to-end media analytics pipeline delivering marketing ROI insights by processing, modeling, and visualizing customer data with attribution and forecasting models.",
+    category: "Data and Analytics",
+    tags: [
+      {
+        name: "python",
+        color: "blue-text-gradient",
+      },
+      {
+        name: "airflow",
+        color: "green-text-gradient",
+      },
+      {
+        name: "prophet",
+        color: "pink-text-gradient",
+      },
+      {
+        name: "docker",
+        color: "blue-text-gradient",
+      },
+    ],
+    image: jobit, // Placeholder Image
+    source_code_link: "https://github.com/MarcusJMyrick/mpad-analytics",
+  },
+  {
+    name: "MMM Data Pipeline Prototype",
+    description:
+      "A production-style, end-to-end ELT data pipeline for a Media Mix Model, automating data ingestion, transformation, and validation using a modern, file-based data stack.",
+    category: "Quantitative Development",
+    tags: [
+      {
+        name: "python",
+        color: "blue-text-gradient",
+      },
+      {
+        name: "dbt",
+        color: "green-text-gradient",
+      },
+      {
+        name: "duckdb",
+        color: "pink-text-gradient",
+      },
+      {
+        name: "bash",
+        color: "blue-text-gradient",
+      },
+    ],
+    image: tripguide, // Placeholder Image
+    source_code_link: "https://github.com/MarcusJMyrick/mmm-data-pipeline",
+  },
+];
+
+export { services, technologies, experiences, projects };

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -4,7 +4,7 @@ import { StarBackground } from "@/components/StarBackground";
 import { HeroSection } from "../components/HeroSection";
 import { AboutSection } from "../components/AboutSection";
 import { SkillsSection } from "../components/SkillsSection";
-import { ProjectsSection } from "../components/ProjectsSection";
+import Projects from "../components/Projects";
 import { ContactSection } from "../components/ContactSection";
 import { Footer } from "../components/Footer";
 
@@ -23,7 +23,7 @@ export const Home = () => {
         <HeroSection />
         <AboutSection />
         <SkillsSection />
-        <ProjectsSection />
+        <Projects />
         <ContactSection />
       </main>
 


### PR DESCRIPTION
## Summary
- personalize hero, navbar, footer, and contact placeholders
- add tailored about text
- add custom project filtering component
- create constants file with project and skill data
- wire new Projects component on home page

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_684c7e3353cc832d8dfa09d9fc117688