### PR TITLE
Fix GitHub Pages base path

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,7 @@ import path from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: "/developer-portfolio/",
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- add base path in vite.config.js for GitHub Pages deployment

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c86d39410832d96680c8b0677beb1